### PR TITLE
Adds _doc to the mappings when using ES < 7

### DIFF
--- a/pgsync/elastichelper.py
+++ b/pgsync/elastichelper.py
@@ -198,4 +198,7 @@ class ElasticHelper(object):
                 node.parent._mapping['properties'][node.label] = node._mapping
 
         if root._mapping:
+            if self.version[0] < 7:
+                root._mapping = { '_doc': root._mapping }
+            
             return dict(mappings=root._mapping)


### PR DESCRIPTION
When using Elasticsearch < 7, the mappings needs to contain a `_doc` object which is currently missing. This addresses an issue bootstrapping when using the `mapping` functionality of `transform`.