### PR TITLE
Adds support for all mapping parameters

### DIFF
--- a/pgsync/constants.py
+++ b/pgsync/constants.py
@@ -107,6 +107,38 @@ ELASTICSEARCH_TYPES = [
     'time',
 ]
 
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-params.html
+ELASTICSEARCH_MAPPING_PARAMETERS = [
+    'analyzer',
+    'boost',
+    'coerce',
+    'copy_to',
+    'doc_values',
+    'dynamic',
+    'eager_global_ordinals',
+    'enabled',
+    'fielddata',
+    'fielddata_frequency_filter',
+    'fields',
+    'format',
+    'ignore_above',
+    'ignore_malformed',
+    'index_options',
+    'index_phrases',
+    'index_prefixes',
+    'index',
+    'meta',
+    'normalizer',
+    'norms',
+    'null_value',
+    'position_increment_gap',
+    'properties',
+    'search_analyzer',
+    'similarity',
+    'store',
+    'term_vector'
+]
+
 CONCAT_TRANSFORM = 'concat'
 MAPPING_TRANSFORM = 'mapping'
 MOVE_TRANSFORM = 'move'

--- a/pgsync/elastichelper.py
+++ b/pgsync/elastichelper.py
@@ -183,6 +183,7 @@ class ElasticHelper(object):
                         f'Invalid Elasticsearch type {column_type}'
                     )
                 fields = mapping[column].get('fields')
+                ignore_above = mapping[column].get('ignore_above')
 
                 if 'properties' not in node._mapping:
                     node._mapping['properties'] = {}
@@ -191,6 +192,8 @@ class ElasticHelper(object):
                 }
                 if fields:
                     node._mapping['properties'][column]['fields'] = fields
+                if ignore_above:
+                    node._mapping['properties'][column]['ignore_above'] = ignore_above
 
             if node.parent and node._mapping:
                 if 'properties' not in node.parent._mapping:
@@ -200,5 +203,5 @@ class ElasticHelper(object):
         if root._mapping:
             if self.version[0] < 7:
                 root._mapping = { '_doc': root._mapping }
-            
+
             return dict(mappings=root._mapping)

--- a/pgsync/elastichelper.py
+++ b/pgsync/elastichelper.py
@@ -7,7 +7,7 @@ from elasticsearch.helpers import parallel_bulk
 from elasticsearch_dsl import Q, Search
 from elasticsearch_dsl.query import Bool
 
-from .constants import ELASTICSEARCH_TYPES, ELASTICSEARCH_MAPPING_PARAMETERS, aMETA
+from .constants import ELASTICSEARCH_TYPES, ELASTICSEARCH_MAPPING_PARAMETERS, META
 from .node import traverse_post_order
 from .settings import (
     ELASTICSEARCH_CA_CERTS,


### PR DESCRIPTION
I originally started working on this because I needed a way to add the `ignore_above` mapping parameter for my project but there are many other [mapping parameters](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-params.html) so I decided to add support for all of them.