### PR TITLE
Fixes an issue where `oid` isn't included in the reflection by sqlalchemy for PostgreSQL < 12

### DIFF
--- a/pgsync/base.py
+++ b/pgsync/base.py
@@ -120,6 +120,7 @@ class Base(object):
                 )
             model = metadata.tables[name]
             model.append_column(sa.Column('xmin', sa.BigInteger))
+            model.append_column(sa.Column('oid', sa.dialects.postgresql.OID))
             model = model.alias()
             setattr(model, 'primary_keys', _get_primary_keys(model))
             self.models[f'{model.original}'] = model


### PR DESCRIPTION
Addresses the `oid` issue for those of us using PostgreSQL < 12 the same way you've addressed the issue for `xmin`. Fixes #107.