### PR TITLE
Addresses an issue where multiple schemas caused duplicate materialized view errors

### DIFF
--- a/pgsync/base.py
+++ b/pgsync/base.py
@@ -441,33 +441,34 @@ class Base(object):
                  table_constraints.c.constraint_type == 'FOREIGN KEY',
             ]).group_by(table_constraints.c.table_name)
 
-    def create_views(self, tables):
-        logger.debug(f'Creating view: {PRIMARY_KEY_VIEW}')
+    def create_views(self, schema, tables):
+        logger.debug(f'Creating view: {schema}.{PRIMARY_KEY_VIEW}')
         self.__engine.execute(
-            CreateView(PRIMARY_KEY_VIEW, self._primary_key_view_statement())
+            CreateView(schema, PRIMARY_KEY_VIEW, self._primary_key_view_statement())
         )
         self.execute(
-            f'CREATE UNIQUE INDEX pkey_idx ON {PRIMARY_KEY_VIEW} (table_name)'
+            f'CREATE UNIQUE INDEX pkey_idx ON "{schema}".{PRIMARY_KEY_VIEW} (table_name)'
         )
-        logger.debug(f'Created view: {PRIMARY_KEY_VIEW}')
+        logger.debug(f'Created view: {schema}.{PRIMARY_KEY_VIEW}')
 
-        logger.debug(f'Creating view: {FOREIGN_KEY_VIEW}')
+        logger.debug(f'Creating view: {schema}.{FOREIGN_KEY_VIEW}')
         self.__engine.execute(
             CreateView(
+                schema,
                 FOREIGN_KEY_VIEW,
                 self._foreign_key_view_statement(tables),
             )
         )
         self.execute(
-            f'CREATE UNIQUE INDEX fkey_idx ON {FOREIGN_KEY_VIEW} (table_name)'
+            f'CREATE UNIQUE INDEX fkey_idx ON "{schema}".{FOREIGN_KEY_VIEW} (table_name)'
         )
-        logger.debug(f'Created view: {FOREIGN_KEY_VIEW}')
+        logger.debug(f'Created view: {schema}.{FOREIGN_KEY_VIEW}')
 
-    def drop_views(self):
+    def drop_views(self, schema):
         for view in [PRIMARY_KEY_VIEW, FOREIGN_KEY_VIEW]:
-            logger.debug(f'Dropping view: {view}')
-            self.__engine.execute(DropView(view))
-            logger.debug(f'Dropped view: {view}')
+            logger.debug(f'Dropping view: {schema}.{view}')
+            self.__engine.execute(DropView(schema, view))
+            logger.debug(f'Dropped view: {schema}.{view}')
 
     # Triggers...
     def create_triggers(self, schema, tables=None):

--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -149,7 +149,7 @@ class Sync(Base):
                 tables |= set(node.relationship.through_tables)
                 tables |= set([node.table])
             self.create_triggers(schema, tables=tables)
-            self.create_views(tables=tables)
+            self.create_views(schema, tables=tables)
         self.create_replication_slot(self.__name)
 
     def teardown(self):
@@ -167,7 +167,7 @@ class Sync(Base):
                 tables |= set(node.relationship.through_tables)
                 tables |= set([node.table])
             self.drop_triggers(schema=schema, tables=tables)
-            self.drop_views()
+            self.drop_views(schema=schema)
         self.drop_replication_slot(self.__name)
 
     def get_doc_id(self, primary_keys):

--- a/pgsync/view.py
+++ b/pgsync/view.py
@@ -3,7 +3,8 @@ from sqlalchemy.schema import DDLElement
 
 
 class CreateView(DDLElement):
-    def __init__(self, name, selectable, materialized=True):
+    def __init__(self, schema, name, selectable, materialized=True):
+        self.schema = schema
         self.name = name
         self.selectable = selectable
         self.materialized = materialized
@@ -16,11 +17,12 @@ def compile_create_view(element, compiler, **kwargs):
         literal_binds=True,
     )
     materialized = 'MATERIALIZED' if element.materialized else ''
-    return f'CREATE {materialized} VIEW {element.name} AS {statement}'
+    return f'CREATE {materialized} VIEW "{element.schema}"."{element.name}" AS {statement}'
 
 
 class DropView(DDLElement):
-    def __init__(self, name, materialized=True, cascade=True):
+    def __init__(self, schema, name, materialized=True, cascade=True):
+        self.schema = schema
         self.name = name
         self.materialized = materialized
         self.cascade = cascade
@@ -30,4 +32,4 @@ class DropView(DDLElement):
 def compile_drop_view(element, compiler, **kwargs):
     materialized = 'MATERIALIZED' if element.materialized else ''
     cascade = 'CASCADE' if element.cascade else ''
-    return f'DROP {materialized} VIEW IF EXISTS {element.name} {cascade}'
+    return f'DROP {materialized} VIEW IF EXISTS "{element.schema}"."{element.name}" {cascade}'


### PR DESCRIPTION
A schema was not provided when creating the new materialized views which caused `psycopg2.errors.DuplicateTable: relation "_pkey_view" already exists` errors for those of us with multiple database schemas. I've addressed issue #108 by adding the schema in the queries.