### PR TITLE
Adds support for schemas and tables with dashes

### DIFF
--- a/pgsync/constants.py
+++ b/pgsync/constants.py
@@ -144,7 +144,7 @@ PRIMARY_KEY_DELIMITER = '|'
 
 # Replication slot patterns
 LOGICAL_SLOT_PREFIX = re.compile(
-    r'table\s(?P<schema>\w+).\"?(?P<table>\w+)\"?:\s(?P<tg_op>[A-Z]+):'
+    r'table\s\"?(?P<schema>[\w-]+)\"?.\"?(?P<table>[\w-]+)\"?:\s(?P<tg_op>[A-Z]+):'
 )
 LOGICAL_SLOT_SUFFIX = re.compile(
     "\s(?P<key>\"?\w+\"?)\[(?P<type>[\w\s]+)\]:(?P<value>[\w\'\"\-]+)"


### PR DESCRIPTION
We have an unusual database schema which contains a dash and that wasn't supported by `LOGICAL_SLOT_PREFIX` so fixed that. I also added support for `"` around the schema since that was also missing.