### PR TITLE
Adds optional support for citext and geoalchemy2

### DIFF
--- a/pgsync/base.py
+++ b/pgsync/base.py
@@ -10,6 +10,16 @@ import sqlparse
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import sessionmaker
 
+try:
+    import citext
+except ImportError:
+    pass
+
+try:
+    import geoalchemy2
+except ImportError:
+    pass
+
 from .constants import (
     BUILTIN_SCHEMAS,
     FOREIGN_KEY_VIEW,


### PR DESCRIPTION
Not everyone uses citext, but we do. Rather than making it a requirement/dependency, I added optional support for citext and geoalchemy2 if they were manually installed.

This remove warnings such as: `SAWarning: Did not recognize type 'citext' of column`.