### PR TITLE
Fixes TypeError: 'NoneType' object is not subscriptable for tables with no primary or foreign keys

### DIFF
--- a/pgsync/trigger.py
+++ b/pgsync/trigger.py
@@ -56,8 +56,8 @@ BEGIN
     -- construct the notification as a JSON object.
     notification = JSON_BUILD_OBJECT(
         'xmin', xmin,
-        'new', new_row,
-        'old', old_row,
+        'new', COALESCE(new_row, JSON_BUILD_OBJECT()),
+        'old', COALESCE(old_row, JSON_BUILD_OBJECT()),
         'tg_op', TG_OP,
         'table', TG_TABLE_NAME,
         'schema', TG_TABLE_SCHEMA


### PR DESCRIPTION
I have some tables with no primary keys and no foreign keys that I use as children. The trigger is returning `NULL` for `old` and `new` which is causing some places where we use payloads to fail.

For example:

```
Exception in thread Thread-23:
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.7/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.7/site-packages/pgsync/sync.py", line 793, in poll_redis
    self.on_publish(payloads)
  File "/usr/local/lib/python3.7/site-packages/pgsync/sync.py", line 880, in on_publish
    self.sync_payloads(_payloads)
  File "/usr/local/lib/python3.7/site-packages/pgsync/sync.py", line 756, in sync_payloads
    payloads,
  File "/usr/local/lib/python3.7/site-packages/pgsync/sync.py", line 389, in _payloads
    value = payload_data[key]
TypeError: 'NoneType' object is not subscriptable
```

This fixes the issue by insuring that `new` and `old` are empty objects instead of `NULL`.

@toluaina I'm not sure if there are any potential side effects to this being an empty dictionary instead of None but this fixes my problem.