### PR TITLE
Rediss support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -58,6 +58,7 @@
 # redis socket connection timeout
 # REDIS_SOCKET_TIMEOUT=5
 # REDIS_POLL_INTERVAL=0.01
+# REDIS_SCHEME=redis
 
 # Logging
 # CRITICAL - 50

--- a/pgsync/redisqueue.py
+++ b/pgsync/redisqueue.py
@@ -82,8 +82,8 @@ class RedisQueue(object):
         self.__db.delete(self.key)
 
 
-def redis_engine(host=None, password=None, port=None, db=None):
-    url = get_redis_url(host=host, password=password, port=port, db=db)
+def redis_engine(schema=None, host=None, password=None, port=None, db=None):
+    url = get_redis_url(schema=scheme, host=host, password=password, port=port, db=db)
     try:
         conn = Redis.from_url(
             url,

--- a/pgsync/redisqueue.py
+++ b/pgsync/redisqueue.py
@@ -82,8 +82,8 @@ class RedisQueue(object):
         self.__db.delete(self.key)
 
 
-def redis_engine(schema=None, host=None, password=None, port=None, db=None):
-    url = get_redis_url(schema=scheme, host=host, password=password, port=port, db=db)
+def redis_engine(scheme=None, host=None, password=None, port=None, db=None):
+    url = get_redis_url(scheme=scheme, host=host, password=password, port=port, db=db)
     try:
         conn = Redis.from_url(
             url,

--- a/pgsync/settings.py
+++ b/pgsync/settings.py
@@ -71,6 +71,7 @@ PG_SSLMODE = env.str('PG_SSLMODE', default=None)
 PG_SSLROOTCERT = env.str('PG_SSLROOTCERT', default=None)
 
 # Redis:
+REDIS_SCHEME = env.str('REDIS_SCHEME', default='redis')
 REDIS_HOST = env.str('REDIS_HOST', default='localhost')
 REDIS_PORT = env.int('REDIS_PORT', default=6379)
 REDIS_DB = env.int('REDIS_DB', default=0)

--- a/pgsync/utils.py
+++ b/pgsync/utils.py
@@ -143,7 +143,7 @@ def get_redis_url(scheme=None, host=None, password=None, port=None, db=None):
     password = password or REDIS_AUTH
     port = port or REDIS_PORT
     db = db or REDIS_DB
-    shcme = scheme or REDIS_SCHEME or 'redis'
+    scheme = scheme or REDIS_SCHEME
     if password:
         return f'{scheme}://:{quote_plus(password)}@{host}:{port}/{db}'
     logger.debug('Connecting to Redis without password.')

--- a/pgsync/utils.py
+++ b/pgsync/utils.py
@@ -22,6 +22,7 @@ from .settings import (
     REDIS_DB,
     REDIS_HOST,
     REDIS_PORT,
+    REDIS_SCHEME,
     SCHEMA,
 )
 
@@ -80,7 +81,7 @@ def show_settings(schema=None, params={}):
             f'{ELASTICSEARCH_HOST}:{ELASTICSEARCH_PORT}'
         )
     logger.info('\033[4mRedis\033[0m:')
-    logger.info(f'URL: redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}')
+    logger.info(f'URL: {REDIS_SCHEME}://{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}')
     logger.info('-' * 65)
 
 
@@ -134,7 +135,7 @@ def get_postgres_url(
     return f'postgresql://{user}@{host}:{port}/{database}'
 
 
-def get_redis_url(host=None, password=None, port=None, db=None):
+def get_redis_url(scheme=None, host=None, password=None, port=None, db=None):
     """
     Return the URL to connect to Redis.
     """
@@ -142,10 +143,11 @@ def get_redis_url(host=None, password=None, port=None, db=None):
     password = password or REDIS_AUTH
     port = port or REDIS_PORT
     db = db or REDIS_DB
+    shcme = scheme or REDIS_SCHEME or 'redis'
     if password:
-        return f'redis://:{quote_plus(password)}@{host}:{port}/{db}'
+        return f'{scheme}://:{quote_plus(password)}@{host}:{port}/{db}'
     logger.debug('Connecting to Redis without password.')
-    return f'redis://{host}:{port}/{db}'
+    return f'{scheme}://{host}:{port}/{db}'
 
 
 def get_config(config=None):


### PR DESCRIPTION
We use TLS with Redis so we need to use `rediss` instead of `redis` as the scheme when connecting. This adds a `REDIS_SCHEME` environment variable which default to `redis` for those of us that use TLS. I chose this way so that it's consistent with how it's done for Elasticsearch.