### PR TITLE
Use ELASTICSEARCH_HOST value instead of parsed url in connection

### DIFF
--- a/pgsync/elastichelper.py
+++ b/pgsync/elastichelper.py
@@ -28,8 +28,7 @@ from .settings import (
     ELASTICSEARCH_THREAD_COUNT,
     ELASTICSEARCH_TIMEOUT,
     ELASTICSEARCH_USE_SSL,
-    ELASTICSEARCH_VERIFY_CERTS,
-    ELASTICSEARCH_HOST
+    ELASTICSEARCH_VERIFY_CERTS
 )
 from .utils import get_elasticsearch_url
 
@@ -220,7 +219,7 @@ def get_elasticsearch_client(url):
     if ELASTICSEARCH_AWS_HOSTED:
         credentials = boto3.Session().get_credentials()
         return Elasticsearch(
-            hosts=[{"host": ELASTICSEARCH_HOST, "port": 443}],
+            hosts=[url],
             http_auth=AWS4Auth(
                 credentials.access_key,
                 credentials.secret_key,

--- a/pgsync/elastichelper.py
+++ b/pgsync/elastichelper.py
@@ -29,6 +29,7 @@ from .settings import (
     ELASTICSEARCH_TIMEOUT,
     ELASTICSEARCH_USE_SSL,
     ELASTICSEARCH_VERIFY_CERTS,
+    ELASTICSEARCH_HOST
 )
 from .utils import get_elasticsearch_url
 
@@ -219,7 +220,7 @@ def get_elasticsearch_client(url):
     if ELASTICSEARCH_AWS_HOSTED:
         credentials = boto3.Session().get_credentials()
         return Elasticsearch(
-            hosts=[{"host": url, "port": 443}],
+            hosts=[{"host": ELASTICSEARCH_HOST, "port": 443}],
             http_auth=AWS4Auth(
                 credentials.access_key,
                 credentials.secret_key,


### PR DESCRIPTION
Incase of AWS hosted elasticsearch we don't have to use the parsed url for constructing the connection, we can directly use the ELASTICSEARCH_HOST variable