### PR TITLE
Fix the regex used for matching the version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_version():
     filename = os.path.join(HERE, "pgsync", "__init__.py")
     with open(filename) as f:
         contents = f.read()
-    pattern = r"^__version__ = '(.*?)'$"
+    pattern = r"^__version__ = \"(.*?)\"$"
     return re.search(pattern, contents, re.MULTILINE).group(1)
 
 


### PR DESCRIPTION
When I tried to run the step `python setup.py develop` mentioned in the contribution docs it was throwing the following error

```
Traceback (most recent call last):
  File "/Users/harishsreeramappa/Desktop/projects/pgsync/setup.py", line 28, in <module>
    VERSION = get_version()
  File "/Users/harishsreeramappa/Desktop/projects/pgsync/setup.py", line 18, in get_version
    return re.search(pattern, contents, re.MULTILINE).group(1)
AttributeError: 'NoneType' object has no attribute 'group'
```

You can also check the publish action https://github.com/toluaina/pgsync/runs/2778103648?check_suite_focus=true