### PR TITLE
Fix "Replication slot names may only contain lower case letters, numbers, and the underscore character."

### DIFF
--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -69,7 +69,7 @@ class Sync(Base):
         )
         self.es = ElasticHelper()
         self.__name = re.sub(
-            "[^0-9a-zA-Z_]+", "", f"{self.database}_{self.index}"
+            "[^0-9a-zA-Z_]+", "", f"{self.database.lower()}_{self.index}"
         )
         self._checkpoint = None
         self._plugins = None


### PR DESCRIPTION
If my database has upper case symbols `bootstrap` gives an error: `HINT:  Replication slot names may only contain lower case letters, numbers, and the underscore character.`, wich arises in `create_replication_slot` function.
I suggest decoupling the database and replication slot names.
but I haven't researched the entire source code, so I'm not sure if the change I proposed won't break something else. Please check and, if everything is good, I will be glad to see my proposed feature in the nearest release.