### PR TITLE
Added search_as_you_type value in ELASTICSEARCH_TYPES

### DIFF
--- a/pgsync/constants.py
+++ b/pgsync/constants.py
@@ -100,6 +100,7 @@ ELASTICSEARCH_TYPES = [
     "nested",
     "null",
     "object",
+    "search_as_you_type",
     "scaled_float",
     "shape",
     "short",


### PR DESCRIPTION
Please merge this as search_as_you_type is supported in elasticsearch field types. https://www.elastic.co/guide/en/elasticsearch/reference/current/search-as-you-type.html