### PR TITLE
batching redis writes

### DIFF
--- a/pgsync/settings.py
+++ b/pgsync/settings.py
@@ -106,6 +106,8 @@ REDIS_DB = env.int("REDIS_DB", default=0)
 REDIS_AUTH = env.str("REDIS_AUTH", default=None)
 # number of items to read from Redis at a time
 REDIS_CHUNK_SIZE = env.int("REDIS_CHUNK_SIZE", default=1000)
+# number of items to write to Redis at a time
+REDIS_WRITE_CHUNK_SIZE = env.int("REDIS_WRITE_CHUNK_SIZE", default=1000)
 # redis socket connection timeout
 REDIS_SOCKET_TIMEOUT = env.int("REDIS_SOCKET_TIMEOUT", default=5)
 # redis poll interval (in secs)

--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -992,13 +992,14 @@ class Sync(Base):
         channel: str = self.database
         cursor.execute(f'LISTEN "{channel}"')
         logger.debug(f'Listening for notifications on channel "{channel}"')
-        item_queue=[]
+        item_queue = []
         while True:
             # NB: consider reducing POLL_TIMEOUT to increase throughout
             if select.select([conn], [], [], POLL_TIMEOUT) == ([], [], []):
                 # Catch any hanging items from the last poll
                 if len(item_queue)>0:
                     self.redis.bulk_push(item_queue)
+                    item_queue = []
                 continue
 
             try:


### PR DESCRIPTION
- Adds the `REDIS_WRITE_CHUNK_SIZE` environment variable which allows pushes to the redis queue to be batched

In reference to #233 I wanted to propose a solution to slow syncs between the database and redis. I was able to get the sync time down from ~2 minutes to 1 minute when inserting ~16k items on my local machine, with a single core dedicated to the process. I think we would see greater improvements on a more powerful computer.

Would love any feedback on this option and your help in verifying it works.