### PR TITLE
Adding option to disable transactional consistency

### DIFF
--- a/pgsync/settings.py
+++ b/pgsync/settings.py
@@ -98,7 +98,7 @@ PG_PORT = env.int("PG_PORT", default=5432)
 PG_PASSWORD = env.str("PG_PASSWORD", default=None)
 PG_SSLMODE = env.str("PG_SSLMODE", default=None)
 PG_SSLROOTCERT = env.str("PG_SSLROOTCERT", default=None)
-PG_TRANSACTIONAL_CONSISTENCY=env.str("PG_TRANSACTIONAL_CONSISTENCY", default=True)
+PG_TRANSACTIONAL_CONSISTENCY=env.bool("PG_TRANSACTIONAL_CONSISTENCY", default=True)
 
 # Redis:
 REDIS_SCHEME = env.str("REDIS_SCHEME", default="redis")

--- a/pgsync/settings.py
+++ b/pgsync/settings.py
@@ -98,6 +98,7 @@ PG_PORT = env.int("PG_PORT", default=5432)
 PG_PASSWORD = env.str("PG_PASSWORD", default=None)
 PG_SSLMODE = env.str("PG_SSLMODE", default=None)
 PG_SSLROOTCERT = env.str("PG_SSLROOTCERT", default=None)
+PG_TRANSACTIONAL_CONSISTENCY=env.str("PG_TRANSACTIONAL_CONSISTENCY", default=True)
 
 # Redis:
 REDIS_SCHEME = env.str("REDIS_SCHEME", default="redis")


### PR DESCRIPTION
When performing interleaved database updates, e.g. for recording item history `INSERT test; INSERT test_history; INSERT test; INSERT test_history;`, pgsync isn't able to bulk query the database or bulk update elasticsearch, due to the requirement of performing the operations in the exact order they occurred.

I wanted to add an optional flag to allow enforcing transactional consistency only at the table level, so that we don't see the performance hit from interleaved operations. I've tried to think of scenarios where this could cause data inconsistency errors after all the operations have been completed, but have yet to think of any.

I would love your input on if this should even be an option or not, and if there could be any data consistency issues, I'm still debating.

This increases performance incredibly for my use case, since it's able to use the batch operations, instead of performing 1000 queries for 1000 inserts.