### PR TITLE
fix(elasticsearch_connection): set api_key arg to None when key id or value are None

### DIFF
--- a/pgsync/elastichelper.py
+++ b/pgsync/elastichelper.py
@@ -333,5 +333,6 @@ def get_elasticsearch_client(url: str) -> Elasticsearch:
             ca_certs=ELASTICSEARCH_CA_CERTS,
             client_cert=ELASTICSEARCH_CLIENT_CERT,
             client_key=ELASTICSEARCH_CLIENT_KEY,
-            api_key=(ELASTICSEARCH_API_KEY_ID, ELASTICSEARCH_API_KEY),
+            api_key=(ELASTICSEARCH_API_KEY_ID, ELASTICSEARCH_API_KEY) if
+            ELASTICSEARCH_API_KEY_ID and ELASTICSEARCH_API_KEY else None,
         )


### PR DESCRIPTION
When connecting to a managed AWS OpenSearch instance without api key, the code fails with the following error:

AuthorizationException(403, [...] not a valid key=value pair (missing equal-sign) in Authorization header: [...]

Setting the api_key argument to None solves the issue

More details here: https://github.com/toluaina/pgsync/issues/245