### PR TITLE
Search `.env` file from current folder, not the executable script folder

### DIFF
--- a/pgsync/settings.py
+++ b/pgsync/settings.py
@@ -2,14 +2,14 @@
 import logging
 import logging.config
 from typing import Optional
+import os
 
 from environs import Env
 
 logger = logging.getLogger(__name__)
 
 env = Env()
-env.read_env()
-
+env.read_env(path=os.path.join(os.getcwd(), ".env"))
 # PGSync:
 # path to the application schema config
 SCHEMA = env.str("SCHEMA", default=None)


### PR DESCRIPTION
In the current project, when using pypi to execute the script, `.env` file will not search start at current path but the bin path.

example:

bootstrap in  `/path/to/python/bin/bootstrap`
current path in  `/user/current/path`

The package `environs` will start to search `.env` from `/path/to/python/bin` ->  `/path/to/python/` ->  `/path/to/` ->  `/path/` ->  `/`

If using source code project, it's not a problem. Because scripts is in the project and `.env` file also in project root path.

But when using pypi, it is not. 

So, I think add a parameter to let `environs` start search at current path is a option.