### PR TITLE
Typo in Sync._refresh_views

### DIFF
--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -1148,7 +1148,7 @@ class Sync(Base):
     def _refresh_views(self) -> None:
         for node in self.root.traverse_breadth_first():
             if node.table in self.views(node.schema):
-                if node.table in self.materialized_views(node.schema):
+                if node.table in self._materialized_views(node.schema):
                     self.refresh_view(node.table, node.schema)
 
     def on_publish(self, payloads: list) -> None:


### PR DESCRIPTION
Just upgraded to 2.3.2 and got the following fatal error:
```
Exception in poll_redis() for thread Thread-94: 'Sync' object has no attribute 'materialized_views'
```
This was the only place in the code that matched.  It looks like this is a simple typo in converting from `self.materialized` to `self._materialized_views`.  There should be an underscore.  Thank you for developing this library.