### PR TITLE
Fixes #142

### DIFF
--- a/pgsync/node.py
+++ b/pgsync/node.py
@@ -288,8 +288,6 @@ class Tree:
         )
 
         self.tables.add(node.table)
-        for through_node in node.relationship.through_nodes:
-            self.tables.add(through_node.table)
 
         for child in data.get("children", []):
             node.add_child(self.build(child))


### PR DESCRIPTION
- When `through_tables` are explicitly specified, the table gets added to the tree when it shouldn't.