### PR TITLE
Fix inserts in through tables

### DIFF
--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -470,23 +470,39 @@ class Sync(Base):
                     )
                     raise
 
-                # set the parent as the new entity that has changed
-                filters[node.parent.table] = []
-                foreign_keys = self.query_builder._get_foreign_keys(
-                    node.parent,
-                    node,
-                )
+                if node in node.parent.relationship.throughs:
+                    through: Node = node.parent.relationship.throughs[0]
+                    foreign_keys = self.query_builder.get_foreign_keys(
+                        through,
+                        node.parent
+                    )
 
-                for payload in payloads:
-                    for i, key in enumerate(foreign_keys[node.name]):
-                        if key == foreign_keys[node.parent.name][i]:
-                            filters[node.parent.table].append(
-                                {
-                                    foreign_keys[node.parent.name][
-                                        i
-                                    ]: payload.data[key]
-                                }
-                            )
+                    filters[node.parent.name] = []
+                    for payload in payloads:
+                        for i, key in enumerate(foreign_keys[node.parent.name]):
+                            filters[node.parent.name].append({
+                                        foreign_keys[node.parent.name][
+                                            i
+                                        ]: payload.data[key]
+                                    })
+                else:
+                    # set the parent as the new entity that has changed
+                    filters[node.parent.table] = []
+                    foreign_keys = self.query_builder._get_foreign_keys(
+                        node.parent,
+                        node,
+                    )
+
+                    for payload in payloads:
+                        for i, key in enumerate(foreign_keys[node.name]):
+                            if key == foreign_keys[node.parent.name][i]:
+                                filters[node.parent.table].append(
+                                    {
+                                        foreign_keys[node.parent.name][
+                                            i
+                                        ]: payload.data[key]
+                                    }
+                                )
 
         else:
 


### PR DESCRIPTION
This fixed the issue for my case, and could _probably_ also fix:

#142
#264
#321


My simplified DB:

```txt
my_customer_groups:
     pk id
     fk my_customer_id   (to id in my_customers)
     fk my_group_id         (to id in my_groups)

my_customers
     pk id
     name

my_groups 
     pk id
     group_name
```
My schema.json
```json
 {
        "database":"my_db",
        "index":"testindex",
        "nodes": {
                    "table":"my_customers",
                    "label":"customers",
                    "columns":[
                        "id",
                        "name",
                    ],
                    "children":[
                         {
                           "table":"my_groups",
                           "columns":[
                                   "id",
                                  "group_name",
                             ],
                           "relationship":{
                                "variant":"object",
                                "type":"one_to_many",
                                "through_tables":[
                                    "my_customer_groups"
                                ]
                            }
                         }
                     ]
         }
 }
```

When the [code reaches this point](https://github.com/toluaina/pgsync/blob/fd6e4bda50fb498e9927c4733a85566255152fb8/pgsync/sync.py#L481) after an insert on the through table I get:

```python
foreign_keys = {'my_customer_groups': ['my_customer_id', 'my_group_id], 'my_customers': ['id'], 'my_groups': ['id']}
```

At that point it fails with this error:

```python
2022-10-17 22:15:57.859:ERROR:pgsync.elastichelper: Exception list index out of range
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/pgsync/elastichelper.py", line 140, in bulk
    raise_on_error=raise_on_error,
  File "/usr/local/lib/python3.7/site-packages/pgsync/elastichelper.py", line 195, in _bulk
    ignore_status=ignore_status,
  File "/usr/local/lib/python3.7/site-packages/elasticsearch/helpers/actions.py", line 484, in parallel_bulk
    actions, chunk_size, max_chunk_bytes, client.transport.serializer
  File "/usr/local/lib/python3.7/multiprocessing/pool.py", line 748, in next
    raise value
  File "/usr/local/lib/python3.7/multiprocessing/pool.py", line 121, in worker
    result = (True, func(*args, **kwds))
  File "/usr/local/lib/python3.7/multiprocessing/pool.py", line 140, in _helper_reraises_exception
    raise ex
  File "/usr/local/lib/python3.7/multiprocessing/pool.py", line 292, in _guarded_task_generation
    for i, x in enumerate(iterable):
  File "/usr/local/lib/python3.7/site-packages/elasticsearch/helpers/actions.py", line 155, in _chunk_actions
    for action, data in actions:
  File "/usr/local/lib/python3.7/site-packages/pgsync/sync.py", line 809, in _payloads
    payloads,
  File "/usr/local/lib/python3.7/site-packages/pgsync/sync.py", line 482, in _insert_op
    if key == foreign_keys[node.parent.name][i]:
IndexError: list index out of range
```
 
I've tried all kinds of configurations, specifying the foreing_keys, transformations, specifying nested types, but nothing works, I ended up debugging and working this out but I think there is an underlying issue.

This bug happens in Postgres 14 and AWS RDS when I use a through table in a child and insert directly into it.

The tests seem to run cleanly, but this workaround is far from ideal. 

Please also check [this line and downwards](https://github.com/toluaina/pgsync/compare/main...mpaolino:pgsync:mpaolino/through_tables?expand=1#diff-d9edc4d9cd53a3ceee5755642d9c09e79cce7fd69ea8774142a87dbc5ee6916bR507), looks like dead code to me, it seems you are adding all through tables to self.tree.tables so I think that block should probably never be reached. Also note that I think this is just a workaround, if I use `filter[node.parent.table]` instead of `filter[node.parent.name]` I will get an exception on insert:

```python
2022-10-24 19:54:55.830:ERROR:pgsync.elastichelper: Exception Select statement '<sqlalchemy.sql.selectable.Select object at 0x7f6684e27ad0>' returned no FROM clauses due to auto-correlation; specify correlate(<tables>) to control correlation manually.
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/pgsync/elastichelper.py", line 140, in bulk
    raise_on_error=raise_on_error,
  File "/usr/local/lib/python3.7/site-packages/pgsync/elastichelper.py", line 195, in _bulk
    ignore_status=ignore_status,
  File "/usr/local/lib/python3.7/site-packages/elasticsearch/helpers/actions.py", line 484, in parallel_bulk
    actions, chunk_size, max_chunk_bytes, client.transport.serializer
  File "/usr/local/lib/python3.7/multiprocessing/pool.py", line 748, in next
    raise value
  File "/usr/local/lib/python3.7/multiprocessing/pool.py", line 121, in worker
    result = (True, func(*args, **kwds))
  File "/usr/local/lib/python3.7/multiprocessing/pool.py", line 140, in _helper_reraises_exception
    raise ex
  File "/usr/local/lib/python3.7/multiprocessing/pool.py", line 292, in _guarded_task_generation
    for i, x in enumerate(iterable):
  File "/usr/local/lib/python3.7/site-packages/elasticsearch/helpers/actions.py", line 155, in _chunk_actions
    for action, data in actions:
  File "/usr/local/lib/python3.7/site-packages/pgsync/sync.py", line 855, in _payloads
    yield from self.sync(filters=filters, extra=extra)
  File "/usr/local/lib/python3.7/site-packages/pgsync/sync.py", line 884, in sync
    count: int = self.fetchcount(node._subquery)
  File "/usr/local/lib/python3.7/site-packages/pgsync/base.py", line 807, in fetchcount
    ).order_by(None)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1380, in execute
    return meth(self, multiparams, params, _EMPTY_EXECUTION_OPTS)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/elements.py", line 334, in _execute_on_connection
    self, multiparams, params, execution_options
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1570, in _execute_clauseelement
    linting=self.dialect.compiler_linting | compiler.WARN_LINTING,
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/elements.py", line 537, in _compile_w_cache
    **kw
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/elements.py", line 566, in _compiler
    return dialect.statement_compiler(dialect, self, **kw)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 790, in __init__
    Compiled.__init__(self, dialect, statement, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 463, in __init__
    self.string = self.process(self.statement, **compile_kwargs)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 498, in process
    return obj._compiler_dispatch(self, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/visitors.py", line 82, in _compiler_dispatch
    return meth(self, **kw)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 3449, in visit_select
    kwargs,
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 3592, in _compose_select_body
    for f in froms
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 3592, in <listcomp>
    for f in froms
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/visitors.py", line 82, in _compiler_dispatch
    return meth(self, **kw)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 3832, in visit_join
    + join.onclause._compiler_dispatch(
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/visitors.py", line 82, in _compiler_dispatch
    return meth(self, **kw)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 2959, in visit_lateral
    return "LATERAL %s" % self.visit_alias(lateral_, **kw)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 2915, in visit_alias
    self, asfrom=True, lateral=lateral, **kwargs
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/visitors.py", line 82, in _compiler_dispatch
    return meth(self, **kw)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 2955, in visit_subquery
    return self.visit_alias(subquery, **kw)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 2894, in visit_alias
    **kwargs
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/visitors.py", line 82, in _compiler_dispatch
    return meth(self, **kw)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 3449, in visit_select
    kwargs,
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 3592, in _compose_select_body
    for f in froms
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 3592, in <listcomp>
    for f in froms
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/visitors.py", line 82, in _compiler_dispatch
    return meth(self, **kw)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 3832, in visit_join
    + join.onclause._compiler_dispatch(
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/visitors.py", line 82, in _compiler_dispatch
    return meth(self, **kw)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 2959, in visit_lateral
    return "LATERAL %s" % self.visit_alias(lateral_, **kw)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 2915, in visit_alias
    self, asfrom=True, lateral=lateral, **kwargs
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/visitors.py", line 82, in _compiler_dispatch
    return meth(self, **kw)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 2955, in visit_subquery
    return self.visit_alias(subquery, **kw)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 2894, in visit_alias
    **kwargs
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/visitors.py", line 82, in _compiler_dispatch
    return meth(self, **kw)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 3353, in visit_select
    select_stmt, compile_state, entry, asfrom, lateral, compound_index
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/compiler.py", line 3529, in _setup_select_stack
    implicit_correlate_froms=asfrom_froms,
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/selectable.py", line 4589, in _get_display_froms
    "manually." % self.statement
sqlalchemy.exc.InvalidRequestError: Select statement '<sqlalchemy.sql.selectable.Select object at 0x7f6684e27ad0>' returned no FROM clauses due to auto-correlation; specify correlate(<tables>) to control correlation manually.
Exception in poll_redis() for thread Thread-48: Select statement '<sqlalchemy.sql.selectable.Select object at 0x7f6684e27ad0>' returned no FROM clauses due to auto-correlation; specify correlate(<tables>) to control correlation manually.
Exiting...
```
I tried to reproduce this bug with the book example with no luck. 

What I can see is that when debugging the _insert_op method is the foreign_keys dictionary generated is not what the code expects. 


I hope this can serve to narrow down the issue and fix it! Cheers.
