### PR TITLE
Fix call to `sorted()` on dicts

### DIFF
--- a/pgsync/base.py
+++ b/pgsync/base.py
@@ -249,9 +249,8 @@ class Base(object):
     def indices(self, table: str, schema: str) -> list:
         """Get the database table indexes."""
         if (table, schema) not in self.__indices:
-            self.__indices[(table, schema)] = sorted(
-                sa.inspect(self.engine).get_indexes(table, schema=schema)
-            )
+            indexes = sa.inspect(self.engine).get_indexes(table, schema=schema)
+            self.__indices[(table, schema)] = sorted(indexes, key=lambda d: d['name'])
         return self.__indices[(table, schema)]
 
     def tables(self, schema: str) -> list:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -110,7 +110,12 @@ class TestBase(object):
 
     def test_indices(self, connection):
         pg_base = Base(connection.engine.url.database)
-        assert pg_base.indices("book", "public") == []
+        assert pg_base.indices("contact_item", "public") == [
+            {'name': 'contact_item_contact_id_key', 'unique': True, 'column_names': ['contact_id'],
+             'include_columns': [], 'duplicates_constraint': 'contact_item_contact_id_key',
+             'dialect_options': {'postgresql_include': []}},
+            {'name': 'contact_item_name_key', 'unique': True, 'column_names': ['name'], 'include_columns': [],
+             'duplicates_constraint': 'contact_item_name_key', 'dialect_options': {'postgresql_include': []}}]
 
     @patch("pgsync.base.logger")
     @patch("pgsync.sync.Base.execute")


### PR DESCRIPTION
Running `—analyze` errors in python 3.11 when indices exist

```bash
File "/Users/lorensiebert/workspace/pgsync/pgsync/base.py", line 252, in indices
    self.__indices[(table, schema)] = sorted(
                                      ^^^^^^^
TypeError: '<' not supported between instances of 'dict' and 'dict'
```