### PR TITLE
Draft: fix handling through table

### DIFF
--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -464,22 +464,46 @@ class Sync(Base):
                     )
                     raise
 
-                # set the parent as the new entity that has changed
-                foreign_keys = self.query_builder._get_foreign_keys(
-                    node.parent,
-                    node,
-                )
+                if node in node.parent.relationship.throughs:
+                    foreign_keys = self.query_builder._get_foreign_keys(
+                        node.parent,
+                        node,
+                    )
 
-                for payload in payloads:
-                    for i, key in enumerate(foreign_keys[node.name]):
-                        if key == foreign_keys[node.parent.name][i]:
-                            filters[node.parent.table].append(
-                                {
-                                    foreign_keys[node.parent.name][
-                                        i
-                                    ]: payload.data[key]
-                                }
-                            )
+                    for payload in payloads:
+                        primary_values: list = [
+                            payload.data[key] for key in node.model.primary_keys
+                        ]
+
+                        for i, key in enumerate(foreign_keys[node.parent.name]):
+                            for val in primary_values:
+                                filters[node.parent.table].append(
+                                    {foreign_keys[node.parent.name][i]: val},
+                                )
+
+                        for pk in self.tree.root.model.primary_keys:
+                            for val in primary_values:
+                                filters[self.tree.root.table].append(
+                                    {pk: val}
+                                )
+
+                else:
+                    # set the parent as the new entity that has changed
+                    foreign_keys = self.query_builder._get_foreign_keys(
+                        node.parent,
+                        node,
+                    )
+
+                    for payload in payloads:
+                        for i, key in enumerate(foreign_keys[node.name]):
+                            if key == foreign_keys[node.parent.name][i]:
+                                filters[node.parent.table].append(
+                                    {
+                                        foreign_keys[node.parent.name][
+                                            i
+                                        ]: payload.data[key]
+                                    }
+                                )
 
         else:
 


### PR DESCRIPTION
Hi @toluaina,
can you take a look at this draft PR? I am trying to fix the `IndexError: list index out of range` error when trying to do an insert in a through table

There's already a PR raised from @mpaolino [here](https://github.com/toluaina/pgsync/pull/361), but it's not resolving for me. This is how my data model looks like

```
my_customer_groups:
     fk my_customer_id   (to id in my_customers)
     fk my_group_id         (to id in my_groups)

my_customers
     pk id
     name

my_groups 
     pk id
     group_name
```


Can you shed some light what would be the preferred approach?

Thanks