### PR TITLE
Fix `get_primary_keys`

### DIFF
--- a/pgsync/transform.py
+++ b/pgsync/transform.py
@@ -225,9 +225,8 @@ class Transform(object):
                         for _v in v:
                             if _v not in target4[key][k]:
                                 target4[key][k].append(_v)
-                        target4[key][k] = target4[key][k]
                     else:
                         if v not in target4[key][k]:
                             target4[key][k].append(v)
-                target4[key][k] = sorted(target4[key][k])
+                    target4[key][k] = sorted(target4[key][k])
         return target4


### PR DESCRIPTION
* About the indentation change: seems like just a typo, but in some cases causes `KeyError` (when for example, the second `key` has empty `value` -- like for a through table without own primary key).
* About the removed line: doesn't seem to be doing anything.