### PR TITLE
Update psycopg2 patch version to update native library

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -122,7 +122,7 @@ pluggy==1.0.0
     # via pytest
 pre-commit==3.2.1
     # via -r requirements/dev.in
-psycopg2-binary==2.9.5
+psycopg2-binary==2.9.6
     # via -r requirements/base.in
 pycodestyle==2.9.1
     # via

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -69,7 +69,7 @@ platformdirs==2.6.2
     # via
     #   black
     #   virtualenv
-psycopg2-binary==2.9.5
+psycopg2-binary==2.9.6
     # via -r requirements/base.in
 python-dateutil==2.8.2
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -106,7 +106,7 @@ platformdirs==2.6.2
     #   virtualenv
 pluggy==1.0.0
     # via pytest
-psycopg2-binary==2.9.5
+psycopg2-binary==2.9.6
     # via -r requirements/base.in
 pycodestyle==2.9.1
     # via


### PR DESCRIPTION
Hi! Thank you so much for maintaining this great tool 😄 I ran into an issue running `pgsync` in my Mac with an M1 chip. It seems that version `2.9.5` of `psycopg2-binary` when precompiled for ARM includes an older version of `libpq` which creates problems when used with certain versions of Postgres. The issue I was seeing has been well documented [here](https://github.com/psycopg/psycopg2/issues/1360) and should be fixed in `2.9.6`. I've updated the version here to match that.

If there are any issues, please let me know!