### PR TITLE
Feature: Add Redis SSL/TLS support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -92,6 +92,10 @@
 # REDIS_SOCKET_TIMEOUT=5
 # REDIS_POLL_INTERVAL=0.01
 # REDIS_SCHEME=redis
+# REDIS_SSL_KEYFILE=/path/to/keyfile
+# REDIS_SSL_CERTFILE=/path/to/certfile
+# REDIS_SSL_CERT_REQS="required"
+# REDIS_SSL_CA_CERT=/path/to/ca_cert
 
 # Logging
 # CRITICAL - 50

--- a/.env.sample
+++ b/.env.sample
@@ -92,6 +92,7 @@
 # REDIS_SOCKET_TIMEOUT=5
 # REDIS_POLL_INTERVAL=0.01
 # REDIS_SCHEME=redis
+# REDIS_SSL=False
 # REDIS_SSL_KEYFILE=/path/to/keyfile
 # REDIS_SSL_CERTFILE=/path/to/certfile
 # REDIS_SSL_CERT_REQS="required"

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,32 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="12">
+            <item index="0" class="java.lang.String" itemvalue="pydantic" />
+            <item index="1" class="java.lang.String" itemvalue="aiosfstream" />
+            <item index="2" class="java.lang.String" itemvalue="aiocometd" />
+            <item index="3" class="java.lang.String" itemvalue="jwt" />
+            <item index="4" class="java.lang.String" itemvalue="aiohttp" />
+            <item index="5" class="java.lang.String" itemvalue="pytest" />
+            <item index="6" class="java.lang.String" itemvalue="jose" />
+            <item index="7" class="java.lang.String" itemvalue="bc-apac-dev" />
+            <item index="8" class="java.lang.String" itemvalue="fastapi" />
+            <item index="9" class="java.lang.String" itemvalue="sqlalchemy" />
+            <item index="10" class="java.lang.String" itemvalue="starlette" />
+            <item index="11" class="java.lang.String" itemvalue="bc-apac-shared" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredIdentifiers">
+        <list>
+          <option value="api.shared.salesforce.*" />
+        </list>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9 (pgsync) (2)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/pgsync.iml" filepath="$PROJECT_DIR$/.idea/pgsync.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/pgsync.iml
+++ b/.idea/pgsync.iml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.9 (pgsync) (2)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,8 @@ expose structured denormalized documents in [Elasticsearch](https://www.elastic.
 - [SQlAlchemy](https://www.sqlalchemy.org) 1.3.4+
 
 ### Postgres setup
-  
-  Enable [logical decoding](https://www.postgresql.org/docs/current/logicaldecoding.html) in your 
+
+  Enable [logical decoding](https://www.postgresql.org/docs/current/logicaldecoding.html) in your
   Postgres setting.
 
   - You also need to set up two parameters in your Postgres config postgresql.conf
@@ -76,7 +76,7 @@ Example spec
         }
     ]
 
-### Environment variables 
+### Environment variables
 
 Setup environment variables required for the application
 
@@ -94,6 +94,14 @@ Setup environment variables required for the application
     REDIS_PORT=6379
     REDIS_DB=0
     REDIS_AUTH=*****
+
+To use SSL/TLS with Redis enable and set these variables
+
+    - REDIS_SSL=True
+    - REDIS_SSL_KEYFILE=/path/to/keyfile
+    - REDIS_SSL_CERTFILE=/path/to/certfile
+    - REDIS_SSL_CERT_REQS="required"
+    - REDIS_SSL_CA_CERT=/path/to/ca_cert
 
 
 ### Running

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,16 @@ services:
   postgres:
     image: debezium/postgres:15
     ports:
-      - "15432:5432"
+      - "5432:5432"
     environment:
       - POSTGRES_USER=pgsync
-      - POSTGRES_PASSWORD=PLEASE_CHANGE_ME
+      - POSTGRES_PASSWORD=test
       - POSTGRES_DB=postgres
   redis:
     image: redis
-    command: redis-server --requirepass PLEASE_CHANGE_ME
+    command: redis-server --requirepass test
+    ports:
+        - "6379:6379"
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.9
     ports:
@@ -42,13 +44,14 @@ services:
       - PG_USER=pgsync
       - PG_HOST=postgres
       - PG_PORT=5432
-      - PG_PASSWORD=PLEASE_CHANGE_ME
+      - PG_PASSWORD=test
       - LOG_LEVEL=INFO
       - ELASTICSEARCH_PORT=9200
       - ELASTICSEARCH_SCHEME=http
       - ELASTICSEARCH_HOST=elasticsearch
+      - REDIS_SSL=False
       - REDIS_HOST=redis
       - REDIS_PORT=6379
-      - REDIS_AUTH=PLEASE_CHANGE_ME
+#      - REDIS_AUTH=test
       - ELASTICSEARCH=true
       - OPENSEARCH=false

--- a/pgsync/redisqueue.py
+++ b/pgsync/redisqueue.py
@@ -30,18 +30,10 @@ class RedisQueue(object):
         self.ssl: bool = kwargs.get("ssl", REDIS_SSL)
 
         if self.ssl:
-            self.ssl_keyfile: str = kwargs.get(
-                "ssl_keyfile", REDIS_SSL_KEYFILE
-            )
-            self.ssl_cert_file: str = kwargs.get(
-                "ssl_cert_file", REDIS_SSL_CERTFILE
-            )
-            self.ssl_cert_reqs: str = kwargs.get(
-                "ssl_cert_reqs", REDIS_SSL_CERT_REQS
-            )
-            self.ssl_ca_certs: str = kwargs.get(
-                "ssl_ca_certs", REDIS_SSL_CA_CERT
-            )
+            self.ssl_keyfile: str = REDIS_SSL_KEYFILE
+            self.ssl_cert_file: str = REDIS_SSL_CERTFILE
+            self.ssl_cert_reqs: str = REDIS_SSL_CERT_REQS
+            self.ssl_ca_certs: str = REDIS_SSL_CA_CERT
 
         try:
             self.__db: Redis = Redis.from_url(

--- a/pgsync/redisqueue.py
+++ b/pgsync/redisqueue.py
@@ -27,7 +27,7 @@ class RedisQueue(object):
         """Init Simple Queue with Redis Backend."""
         url: str = get_redis_url(**kwargs)
         self.key: str = f"{namespace}:{name}"
-        self.ssl: bool = REDIS_SSL
+        self.ssl: bool = kwargs.get("ssl", REDIS_SSL)
         self.redis_ssl_args: dict = {}
 
         if self.ssl:
@@ -37,8 +37,6 @@ class RedisQueue(object):
                 ssl_cert_reqs=REDIS_SSL_CERT_REQS,
                 ssl_ca_certs=REDIS_SSL_CA_CERT,
             )
-
-        logger.debug(f"Redis SSL Arguments: {self.redis_ssl_args}")
 
         try:
             self.__db: Redis = Redis.from_url(

--- a/pgsync/redisqueue.py
+++ b/pgsync/redisqueue.py
@@ -9,6 +9,7 @@ from redis.exceptions import ConnectionError
 from .settings import (
     REDIS_READ_CHUNK_SIZE,
     REDIS_SOCKET_TIMEOUT,
+    REDIS_SSL,
     REDIS_SSL_CA_CERT,
     REDIS_SSL_CERT_REQS,
     REDIS_SSL_CERTFILE,
@@ -26,14 +27,14 @@ class RedisQueue(object):
         """Init Simple Queue with Redis Backend."""
         url: str = get_redis_url(**kwargs)
         self.key: str = f"{namespace}:{name}"
-        self.ssl: bool = kwargs.get("ssl")
+        self.ssl: bool = kwargs.get("ssl", REDIS_SSL)
 
         if self.ssl:
             self.ssl_keyfile: str = kwargs.get(
                 "ssl_keyfile", REDIS_SSL_KEYFILE
             )
-            self.ssl_certfile: str = kwargs.get(
-                "ssl_certfile", REDIS_SSL_CERTFILE
+            self.ssl_cert_file: str = kwargs.get(
+                "ssl_cert_file", REDIS_SSL_CERTFILE
             )
             self.ssl_cert_reqs: str = kwargs.get(
                 "ssl_cert_reqs", REDIS_SSL_CERT_REQS
@@ -47,7 +48,7 @@ class RedisQueue(object):
                 url,
                 socket_timeout=REDIS_SOCKET_TIMEOUT,
                 ssl_keyfile=self.ssl_keyfile,
-                ssl_certfile=self.ssl_certfile,
+                ssl_certfile=self.ssl_cert_file,
                 ssl_cert_reqs=self.ssl_cert_reqs,
                 ssl_ca_certs=self.ssl_ca_certs,
             )

--- a/pgsync/redisqueue.py
+++ b/pgsync/redisqueue.py
@@ -27,22 +27,22 @@ class RedisQueue(object):
         """Init Simple Queue with Redis Backend."""
         url: str = get_redis_url(**kwargs)
         self.key: str = f"{namespace}:{name}"
-        self.ssl: bool = kwargs.get("ssl", REDIS_SSL)
+        self.ssl: bool = REDIS_SSL
+        self.redis_ssl_args: dict = {}
 
         if self.ssl:
-            self.ssl_keyfile: str = REDIS_SSL_KEYFILE
-            self.ssl_cert_file: str = REDIS_SSL_CERTFILE
-            self.ssl_cert_reqs: str = REDIS_SSL_CERT_REQS
-            self.ssl_ca_certs: str = REDIS_SSL_CA_CERT
+            self.redis_ssl_args = dict(
+                ssl_keyfile=REDIS_SSL_KEYFILE,
+                ssl_certfile=REDIS_SSL_CERTFILE,
+                ssl_cert_reqs=REDIS_SSL_CERT_REQS,
+                ssl_ca_certs=REDIS_SSL_CA_CERT,
+            )
 
         try:
             self.__db: Redis = Redis.from_url(
                 url,
                 socket_timeout=REDIS_SOCKET_TIMEOUT,
-                ssl_keyfile=self.ssl_keyfile,
-                ssl_certfile=self.ssl_cert_file,
-                ssl_cert_reqs=self.ssl_cert_reqs,
-                ssl_ca_certs=self.ssl_ca_certs,
+                **self.redis_ssl_args,
             )
             self.__db.ping()
         except ConnectionError as e:

--- a/pgsync/redisqueue.py
+++ b/pgsync/redisqueue.py
@@ -38,6 +38,8 @@ class RedisQueue(object):
                 ssl_ca_certs=REDIS_SSL_CA_CERT,
             )
 
+        logger.debug(f"Redis SSL Arguments: {self.redis_ssl_args}")
+
         try:
             self.__db: Redis = Redis.from_url(
                 url,

--- a/pgsync/settings.py
+++ b/pgsync/settings.py
@@ -150,7 +150,6 @@ REDIS_PORT = env.int("REDIS_PORT", default=6379)
 REDIS_READ_CHUNK_SIZE = env.int("REDIS_READ_CHUNK_SIZE", default=1000)
 REDIS_SCHEME = env.str("REDIS_SCHEME", default="redis")
 # redis ssl configuration
-REDIS_SSL_SCHEME = env.str("REDIS_SSL_SCHEME", default="rediss")
 REDIS_SSL = env.bool("REDIS_SSL", default=False)
 REDIS_SSL_CA_CERT = env.str("REDIS_SSL_CA_CERT", default=None)
 REDIS_SSL_KEYFILE = env.str("REDIS_SSL_KEYFILE", default=None)

--- a/pgsync/settings.py
+++ b/pgsync/settings.py
@@ -154,7 +154,7 @@ REDIS_SSL = env.bool("REDIS_SSL", default=False)
 REDIS_SSL_CA_CERT = env.str("REDIS_SSL_CA_CERT", default=None)
 REDIS_SSL_KEYFILE = env.str("REDIS_SSL_KEYFILE", default=None)
 REDIS_SSL_CERTFILE = env.str("REDIS_SSL_CERTFILE", default=None)
-REDIS_SSL_CERT_REQS = env.str("REDIS_SSL_CERT_REQS", default=None)
+REDIS_SSL_CERT_REQS = env.str("REDIS_SSL_CERT_REQS", default="required")
 # redis socket connection timeout
 REDIS_SOCKET_TIMEOUT = env.int("REDIS_SOCKET_TIMEOUT", default=5)
 # number of items to write to Redis at a time

--- a/pgsync/settings.py
+++ b/pgsync/settings.py
@@ -149,6 +149,7 @@ REDIS_PORT = env.int("REDIS_PORT", default=6379)
 # number of items to read from Redis at a time
 REDIS_READ_CHUNK_SIZE = env.int("REDIS_READ_CHUNK_SIZE", default=1000)
 REDIS_SCHEME = env.str("REDIS_SCHEME", default="redis")
+# redis ssl configuration
 REDIS_SSL_SCHEME = env.str("REDIS_SSL_SCHEME", default="rediss")
 REDIS_SSL = env.bool("REDIS_SSL", default=False)
 REDIS_SSL_CA_CERT = env.str("REDIS_SSL_CA_CERT", default=None)

--- a/pgsync/settings.py
+++ b/pgsync/settings.py
@@ -179,7 +179,7 @@ def _get_logging_config(silent_loggers: Optional[str] = None):
                 "class": "logging.StreamHandler",
                 "level": env.str(
                     "CONSOLE_LOGGING_HANDLER_MIN_LEVEL",
-                    default="DEBUG",
+                    default="WARNING",
                 ),
                 "formatter": "simple",
             },

--- a/pgsync/settings.py
+++ b/pgsync/settings.py
@@ -179,7 +179,7 @@ def _get_logging_config(silent_loggers: Optional[str] = None):
                 "class": "logging.StreamHandler",
                 "level": env.str(
                     "CONSOLE_LOGGING_HANDLER_MIN_LEVEL",
-                    default="WARNING",
+                    default="DEBUG",
                 ),
                 "formatter": "simple",
             },

--- a/pgsync/settings.py
+++ b/pgsync/settings.py
@@ -6,6 +6,8 @@ from typing import Optional
 
 from environs import Env
 
+from pgsync.constants import DEFAULT_SCHEMA
+
 logger = logging.getLogger(__name__)
 
 env = Env()
@@ -138,6 +140,7 @@ PG_PORT = env.int("PG_PORT", default=5432)
 PG_SSLMODE = env.str("PG_SSLMODE", default=None)
 PG_SSLROOTCERT = env.str("PG_SSLROOTCERT", default=None)
 PG_USER = env.str("PG_USER")
+PG_SCHEMAS = env.list("PG_SCHEMAS", default=[DEFAULT_SCHEMA])
 
 # Redis:
 REDIS_AUTH = env.str("REDIS_AUTH", default=None)

--- a/pgsync/settings.py
+++ b/pgsync/settings.py
@@ -149,6 +149,12 @@ REDIS_PORT = env.int("REDIS_PORT", default=6379)
 # number of items to read from Redis at a time
 REDIS_READ_CHUNK_SIZE = env.int("REDIS_READ_CHUNK_SIZE", default=1000)
 REDIS_SCHEME = env.str("REDIS_SCHEME", default="redis")
+REDIS_SSL_SCHEME = env.str("REDIS_SSL_SCHEME", default="rediss")
+REDIS_SSL = env.bool("REDIS_SSL", default=False)
+REDIS_SSL_CA_CERT = env.str("REDIS_SSL_CA_CERT", default=None)
+REDIS_SSL_KEYFILE = env.str("REDIS_SSL_KEYFILE", default=None)
+REDIS_SSL_CERTFILE = env.str("REDIS_SSL_CERTFILE", default=None)
+REDIS_SSL_CERT_REQS = env.str("REDIS_SSL_CERT_REQS", default=None)
 # redis socket connection timeout
 REDIS_SOCKET_TIMEOUT = env.int("REDIS_SOCKET_TIMEOUT", default=5)
 # number of items to write to Redis at a time

--- a/pgsync/urls.py
+++ b/pgsync/urls.py
@@ -21,8 +21,6 @@ from .settings import (
     REDIS_HOST,
     REDIS_PORT,
     REDIS_SCHEME,
-    REDIS_SSL,
-    REDIS_SSL_SCHEME,
 )
 
 logger = logging.getLogger(__name__)
@@ -88,7 +86,6 @@ def get_redis_url(
     password: Optional[str] = None,
     port: Optional[int] = None,
     db: Optional[str] = None,
-    ssl: Optional[bool] = False,
 ) -> str:
     """Return the URL to connect to Redis."""
     host = host or REDIS_HOST
@@ -96,10 +93,7 @@ def get_redis_url(
     port = port or REDIS_PORT
     db = db or REDIS_DB
     scheme = scheme or REDIS_SCHEME
-    ssl = ssl or REDIS_SSL
 
-    if ssl:
-        scheme = REDIS_SSL_SCHEME
     if password:
         return f"{scheme}://:{quote_plus(password)}@{host}:{port}/{db}"
     logger.debug("Connecting to Redis without password.")

--- a/pgsync/urls.py
+++ b/pgsync/urls.py
@@ -100,6 +100,7 @@ def get_redis_url(
 
     if ssl:
         scheme = REDIS_SSL_SCHEME
+        logger.debug(f"SSL scheme: {scheme}")
         return f"{scheme}://:{quote_plus(password)}@{host}:{port}/{db}"
     if password:
         return f"{scheme}://:{quote_plus(password)}@{host}:{port}/{db}"

--- a/pgsync/urls.py
+++ b/pgsync/urls.py
@@ -100,7 +100,6 @@ def get_redis_url(
 
     if ssl:
         scheme = REDIS_SSL_SCHEME
-        logger.debug(f"SSL scheme: {scheme}")
         return f"{scheme}://:{quote_plus(password)}@{host}:{port}/{db}"
     if password:
         return f"{scheme}://:{quote_plus(password)}@{host}:{port}/{db}"

--- a/pgsync/urls.py
+++ b/pgsync/urls.py
@@ -86,6 +86,7 @@ def get_redis_url(
     password: Optional[str] = None,
     port: Optional[int] = None,
     db: Optional[str] = None,
+    ssl: Optional[bool] = False,
 ) -> str:
     """Return the URL to connect to Redis."""
     host = host or REDIS_HOST
@@ -94,6 +95,8 @@ def get_redis_url(
     db = db or REDIS_DB
     scheme = scheme or REDIS_SCHEME
 
+    if ssl:
+        scheme = "rediss"
     if password:
         return f"{scheme}://:{quote_plus(password)}@{host}:{port}/{db}"
     logger.debug("Connecting to Redis without password.")

--- a/pgsync/urls.py
+++ b/pgsync/urls.py
@@ -21,6 +21,8 @@ from .settings import (
     REDIS_HOST,
     REDIS_PORT,
     REDIS_SCHEME,
+    REDIS_SSL,
+    REDIS_SSL_SCHEME,
 )
 
 logger = logging.getLogger(__name__)
@@ -86,6 +88,7 @@ def get_redis_url(
     password: Optional[str] = None,
     port: Optional[int] = None,
     db: Optional[str] = None,
+    ssl: Optional[bool] = False,
 ) -> str:
     """Return the URL to connect to Redis."""
     host = host or REDIS_HOST
@@ -93,6 +96,11 @@ def get_redis_url(
     port = port or REDIS_PORT
     db = db or REDIS_DB
     scheme = scheme or REDIS_SCHEME
+    ssl = ssl or REDIS_SSL
+
+    if ssl:
+        scheme = REDIS_SSL_SCHEME
+        return f"{scheme}://:{quote_plus(password)}@{host}:{port}/{db}"
     if password:
         return f"{scheme}://:{quote_plus(password)}@{host}:{port}/{db}"
     logger.debug("Connecting to Redis without password.")

--- a/pgsync/urls.py
+++ b/pgsync/urls.py
@@ -100,7 +100,6 @@ def get_redis_url(
 
     if ssl:
         scheme = REDIS_SSL_SCHEME
-        return f"{scheme}://:{quote_plus(password)}@{host}:{port}/{db}"
     if password:
         return f"{scheme}://:{quote_plus(password)}@{host}:{port}/{db}"
     logger.debug("Connecting to Redis without password.")

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -73,6 +73,7 @@ class TestUrls(object):
             == "redis://:1234@localhost:9999/0"
         )
         assert get_redis_url(host="skynet") == "redis://skynet:6379/0"
+        assert get_redis_url(ssl=True) == "rediss://localhost:6379/0"
 
     @patch("pgsync.urls.logger")
     def test_get_config(self, mock_logger):


### PR DESCRIPTION
Description:

As mentioned in the issue #444, `pgsync` currently does not support connecting to redis via SSL/TLS. This proves to be a challenge in environments where a SSL/TLS connection is required for Redis.

Todo:
- [x] Add unit tests
- [x] Update documentation