### PR TITLE
Support AWS OpenSearch Serverless

### DIFF
--- a/pgsync/search_client.py
+++ b/pgsync/search_client.py
@@ -350,7 +350,7 @@ def get_search_client(
 ) -> Union[opensearchpy.OpenSearch, elasticsearch.Elasticsearch]:
     if settings.OPENSEARCH_AWS_HOSTED or settings.ELASTICSEARCH_AWS_HOSTED:
         credentials = boto3.Session().get_credentials()
-        service: str = "es"
+        service: str = "aoss" if settings.OPENSEARCH_AWS_SERVERLESS else "es"
         return client(
             hosts=[url],
             http_auth=AWS4Auth(

--- a/pgsync/settings.py
+++ b/pgsync/settings.py
@@ -130,6 +130,7 @@ ELASTICSEARCH_IGNORE_STATUS = tuple(map(int, ELASTICSEARCH_IGNORE_STATUS))
 ELASTICSEARCH = env.bool("ELASTICSEARCH", default=True)
 OPENSEARCH = env.bool("OPENSEARCH", default=(not ELASTICSEARCH))
 OPENSEARCH_AWS_HOSTED = env.bool("OPENSEARCH_AWS_HOSTED", default=False)
+OPENSEARCH_AWS_SERVERLESS = env.bool("OPENSEARCH_AWS_SERVERLESS", default=False) # noqa E501
 
 # Postgres:
 PG_HOST = env.str("PG_HOST", default="localhost")


### PR DESCRIPTION
Adds support for AWS Opensearch Serverless, which requires the service name `aoss` instead of `es` when instantiating the search client. 

Users must set the `OPENSEARCH_AWS_SERVERLESS` environment variable to `true` to allow the proper search client configuration.

Reference: https://github.com/opensearch-project/opensearch-py/blob/main/guides/auth.md