### PR TITLE
Fix missing delta inserts of children

### DIFF
--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -562,14 +562,19 @@ class Sync(Base, metaclass=Singleton):
                         node,
                     )
 
-                _filters: list = []
                 for payload in payloads:
+                    _filters: list = []
+
                     for node_key in foreign_keys[node.name]:
                         for parent_key in foreign_keys[node.parent.name]:
                             if node_key == parent_key:
                                 filters[node.parent.table].append(
                                     {parent_key: payload.data[node_key]}
                                 )
+
+                    _filters = self._root_primary_key_resolver(
+                        node, payload, _filters
+                    )
 
                     _filters = self._root_foreign_key_resolver(
                         node, payload, foreign_keys, _filters
@@ -581,8 +586,8 @@ class Sync(Base, metaclass=Singleton):
                             node, payload, _filters
                         )
 
-                if _filters:
-                    filters[self.tree.root.table].extend(_filters)
+                    if _filters:
+                        filters[self.tree.root.table].extend(_filters)
 
         else:
             # handle case where we insert into a through table


### PR DESCRIPTION
When pgsync is catching up to changes via PG_NOTIFY or replication slots, it is missing inserts of first-level children. This commit is fixing the issue.