### PR TITLE
fix issue with outerjoin when there are repeated tables

### DIFF
--- a/pgsync/node.py
+++ b/pgsync/node.py
@@ -103,6 +103,7 @@ class Node(object):
     models: Callable
     table: str
     schema: str
+    table_count: Optional[int] = None
     primary_key: Optional[list] = None
     label: Optional[str] = None
     transform: Optional[dict] = None
@@ -259,6 +260,7 @@ class Tree:
 
     def __post_init__(self):
         self.tables: Set[str] = set()
+        self.table_counts: Dict[str, int] = {}
         self.__nodes: Dict[Node] = {}
         self.root: Optional[Node] = None
 
@@ -271,7 +273,7 @@ class Tree:
     def traverse_post_order(self) -> Generator:
         return self.root.traverse_post_order()
 
-    def build(self, data: dict) -> Node:
+    def build(self, data: dict, is_root: bool = True) -> Node:
         if not isinstance(data, dict):
             raise SchemaError(
                 "Incompatible schema. Please run v2 schema migration"
@@ -302,13 +304,19 @@ class Tree:
             self.root = node
 
         self.tables.add(node.table)
+        if node.table not in self.table_counts:
+            self.table_counts[node.table] = 0
+        self.table_counts[node.table] += 1
         for through in node.relationship.throughs:
             self.tables.add(through.table)
 
         for child in data.get("children", []):
-            node.add_child(self.build(child))
+            node.add_child(self.build(child, is_root=False))
 
         self.__nodes[key] = node
+        if is_root:
+            for child_node in self.traverse_post_order():
+                child_node.table_count = self.table_counts[child_node.table]
         return node
 
     def get_node(self, table: str, schema: str) -> Node:

--- a/pgsync/querybuilder.py
+++ b/pgsync/querybuilder.py
@@ -396,9 +396,11 @@ class QueryBuilder(object):
                 self.from_obj = child.parent.model
 
             if child._filters:
-                self.isouter = False
+                if child.table_count <= 1:
+                    self.isouter = False
                 for _filter in child._filters:
                     if isinstance(_filter, sa.sql.elements.BinaryExpression):
+
                         for column in _filter._orig:
                             if hasattr(column, "value"):
                                 _column = child._subquery.c
@@ -546,8 +548,8 @@ class QueryBuilder(object):
                 from_obj = node.model
 
             if child._filters:
-                self.isouter = False
-
+                if child.table_count <= 1:
+                    self.isouter = False
                 for _filter in child._filters:
                     if isinstance(_filter, sa.sql.elements.BinaryExpression):
                         for column in _filter._orig:
@@ -667,7 +669,8 @@ class QueryBuilder(object):
             )
 
         if node._filters:
-            self.isouter = False
+            if node.table_count <= 1:
+                self.isouter = False
 
         op = sa.and_
         if node.table == node.parent.table:
@@ -723,7 +726,8 @@ class QueryBuilder(object):
                 from_obj = node.model
 
             if child._filters:
-                self.isouter = False
+                if child.table_count <= 1:
+                    self.isouter = False
 
                 for _filter in child._filters:
                     if isinstance(_filter, sa.sql.elements.BinaryExpression):


### PR DESCRIPTION
This is a fix for https://github.com/toluaina/pgsync/issues/243, we notice that outer joins are disabled when any child has a filter applied, however, if a table is repeated then outerjoins should always be used when performing updates.
 