### PR TITLE
Fixes #527: Bugfix LOGICAL_SLOT_SUFFIX regex

### DIFF
--- a/pgsync/constants.py
+++ b/pgsync/constants.py
@@ -208,5 +208,5 @@ LOGICAL_SLOT_PREFIX = re.compile(
     r"table\s\"?(?P<schema>[\w-]+)\"?.\"?(?P<table>[\w-]+)\"?:\s(?P<tg_op>[A-Z]+):"  # noqa E501
 )
 LOGICAL_SLOT_SUFFIX = re.compile(
-    '\s(?P<key>"?\w+"?)\[(?P<type>[\w\s]+)\]:(?P<value>[\w\'"\-]+)'
+    '\s(?P<key>"?\w+"?)\[(?P<type>[\w\s]+)\]:(?P<value>[\w\'"\-\\.\\+]+)'
 )


### PR DESCRIPTION
Bugfix for replication regex to parse double values served like 2.3e+09, seems to be working fine for me, propably requires some more testing  
fixes #527