### PR TITLE
docker compose: add kibana and add optional EXAMPLE_NAME build arg to select example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ ADD ./examples/ $WORKDIR/examples
 WORKDIR $WORKDIR
 RUN pip install git+https://github.com/toluaina/pgsync.git
 COPY ./docker/wait-for-it.sh wait-for-it.sh
+ARG EXAMPLE_NAME=airbnb
+ENV EXAMPLE_NAME=$EXAMPLE_NAME
 COPY ./docker/runserver.sh runserver.sh
 RUN chmod +x wait-for-it.sh
 RUN chmod +x runserver.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,14 @@ services:
       - xpack.security.enabled=false
       - network.host=127.0.0.1
       - http.host=0.0.0.0
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.17.13
+    ports:
+      - "5601:5601"
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    depends_on:
+      - elasticsearch
   pgsync:
     build:
       context: .

--- a/docker/runserver.sh
+++ b/docker/runserver.sh
@@ -6,7 +6,7 @@
 
 ./wait-for-it.sh $REDIS_HOST:$REDIS_PORT -t 60
 
-EXAMPLE_DIR="examples/airbnb"
+EXAMPLE_DIR="examples/${EXAMPLE_NAME:-airbnb}"
 
 python $EXAMPLE_DIR/schema.py --config $EXAMPLE_DIR/schema.json
 


### PR DESCRIPTION
- adds kibana to the elasticsearch docker compose file
- add optional docker build arg EXAMPLE_NAME to select which test folder to select