### PR TITLE
Update regex to add values with space characters also

### DIFF
--- a/pgsync/constants.py
+++ b/pgsync/constants.py
@@ -208,5 +208,5 @@ LOGICAL_SLOT_PREFIX = re.compile(
     r"table\s\"?(?P<schema>[\w-]+)\"?.\"?(?P<table>[\w-]+)\"?:\s(?P<tg_op>[A-Z]+):"  # noqa E501
 )
 LOGICAL_SLOT_SUFFIX = re.compile(
-    '\s(?P<key>"?\w+"?)\[(?P<type>[\w\s]+)\]:(?P<value>[\w\'"\-\\.\\+]+)'
+    r'\s(?P<key>"?\w+"?)\[(?P<type>[\w\s]+)\]:(?P<value>[\w\'"\-\\.\\+ ]+)'   # noqa E501
 )


### PR DESCRIPTION
### Need to Incorporate space characters in value:

Currently, the logical slot suffix restricts values by disallowing spaces, permitting only word characters, single quotes, double quotes, hyphens, dots, and plus signs. However, values can also include spaces. For instance, the _title_ column often contains values with multiple words separated by spaces. Hence, we need to adjust the logic to incorporate **spaces** in values.