### PR TITLE
Add More Error Logging When Indexing Fails

### DIFF
--- a/pgsync/search_client.py
+++ b/pgsync/search_client.py
@@ -174,7 +174,7 @@ class SearchClient(object):
     ):
         """Bulk index, update, delete docs to Elasticsearch/OpenSearch."""
         if settings.ELASTICSEARCH_STREAMING_BULK:
-            for ok, _ in self.streaming_bulk(
+            for ok, info in self.streaming_bulk(
                 self.__client,
                 actions,
                 index=index,
@@ -189,10 +189,12 @@ class SearchClient(object):
             ):
                 if ok:
                     self.doc_count += 1
+                else:
+                    logger.error(f"Document failed to index: {info}")
         else:
             # parallel bulk consumes more memory and is also more likely
             # to result in 429 errors.
-            for ok, _ in self.parallel_bulk(
+            for ok, info in self.parallel_bulk(
                 self.__client,
                 actions,
                 thread_count=thread_count,
@@ -206,6 +208,8 @@ class SearchClient(object):
             ):
                 if ok:
                     self.doc_count += 1
+                else:
+                    logger.error(f"Document failed to index: {info}")
 
     def refresh(self, indices: t.List[str]) -> None:
         """Refresh the Elasticsearch/OpenSearch index."""


### PR DESCRIPTION
In trying to debug an issue, I needed to add more logging to PGSync in order to see the problem. This PR adds additional logging similar to [this one](https://discuss.elastic.co/t/helpers-parallel-bulk-in-python-not-working/39498/2) within the Elasticsearch community.

Before, I would see messages like:

```
BulkIndexError: ('1 document(s) failed to index.')
```

While this did indicate something was wrong with the document, I did not know which one or why it was problematic. With this change, I now see errors containing:

```
{..., 'reason': 'Document contains at least one immense term in field="description" ...}
```

This along with additional information (such as the document shape (including `id`) have been valuable information.

**Note**: This logging will only be visible with `ELASTICSEARCH_RAISE_ON_ERROR="false"` and `ELASTICSEARCH_RAISE_ON_EXCEPTION="false"`. This was thanks to the suggestion within https://github.com/toluaina/pgsync/issues/503#issuecomment-1832058419