### PR TITLE
Update constants.py

### DIFF
--- a/pgsync/constants.py
+++ b/pgsync/constants.py
@@ -135,6 +135,7 @@ ELASTICSEARCH_MAPPING_PARAMETERS = [
     "boost",
     "coerce",
     "copy_to",
+    "dimension",
     "doc_values",
     "dynamic",
     "eager_global_ordinals",


### PR DESCRIPTION
Added "dimension" parameter to define the number of dimensions when using the knn_vector type in OpenSearch.
(Ref.: [Parameters in OpenSearch](https://docs.opensearch.org/docs/latest/field-types/supported-field-types/knn-vector/#:~:text=knn_vector.%20Required.-,dimension,-Integer))