### PR TITLE
Skip logical slot processing in PostgreSQL polling mode

### DIFF
--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -2020,6 +2020,12 @@ class Sync(Base, metaclass=Singleton):
             self.index, self.sync(txmin=txmin, txmax=txmax)
         )
 
+        # PostgreSQL polling uses only the forward pass and has no logical
+        # replication slot, so advance its safe snapshot checkpoint directly.
+        if polling and not self.is_mysql_compat:
+            self.checkpoint = snapshot_xmin
+            return
+
         if self.is_mysql_compat:
             self.binlog_changes(
                 start_log=start_log,

--- a/tests/test_sync_polling.py
+++ b/tests/test_sync_polling.py
@@ -19,6 +19,29 @@ def make_sync():
     )
 
 
+def test_pull_polling_updates_checkpoint_without_logical_slot():
+    """PostgreSQL polling must not depend on logical replication."""
+    docs = [{"_id": "1"}]
+    sync = SimpleNamespace(
+        is_mysql_compat=False,
+        checkpoint=1,
+        txid_snapshot_xmin=100,
+        txid_current=200,
+        current_wal_lsn="0/16B6C50",
+        index="testdb",
+        search_client=Mock(),
+        sync=Mock(return_value=docs),
+        logical_slot_changes=Mock(),
+        _truncate=False,
+    )
+
+    Sync.pull(sync, polling=True)
+
+    assert sync.checkpoint == 100
+    sync.logical_slot_changes.assert_not_called()
+    sync.search_client.bulk.assert_called_once_with("testdb", docs)
+
+
 def test_poll_db_once_flushes_buffer_when_notification_wait_times_out():
     sync = make_sync()
     conn = Mock()


### PR DESCRIPTION
## Summary

- advance the PostgreSQL polling checkpoint after each successful forward pass
- skip WAL and logical replication-slot processing in polling mode
- add regression coverage

## Problem

PGSync documents `--polling` as operating
[instead of logical replication](https://pgsync.com/command-args/#modes)
and requiring
[only database read access](https://pgsync.com/django/#run-modes).

However, `Sync.pull(polling=True)` still calls logical-slot operations. If
the slot is missing or the user lacks replication privileges, the checkpoint
is not updated, causing the same rows—or the full table—to be scanned again
on every cycle.

## Solution

After a successful forward pass, PostgreSQL polling mode now stores the
captured `snapshot_xmin` checkpoint and returns before accessing the WAL or
logical replication slot.

MySQL/MariaDB and PostgreSQL replication-based modes are unchanged.

## Tests

- `pytest tests/test_sync_polling.py -vv`
- `./scripts/lint.sh`